### PR TITLE
Fix #183: Apply YUYV to RGB Conversion in Camera Stream

### DIFF
--- a/apps/camera/src/contexts/camera.rs
+++ b/apps/camera/src/contexts/camera.rs
@@ -245,7 +245,12 @@ impl Camera {
                 Camera::get();
                 match GST_CAMERA.lock().unwrap().as_mut().unwrap().frame() {
                     Ok(f) => {
-                        Self::get().frame_buffer.set(f);
+                        let raw_data = f.as_raw();
+                        let buffer = yuyv422_to_rgb(raw_data, true).unwrap();
+                        let width = *Self::get().width.get();
+                        let height = *Self::get().height.get();
+                        let frame = ImageBuffer::from_raw(width, height, buffer).unwrap();
+                        Self::get().frame_buffer.set(frame);
                     }
                     Err(e) => {
                         println!("error from frame {:?}", e);


### PR DESCRIPTION
#183
# Changes

- **Modified:** `start_fetching()` to convert YUYV frames to RGBA using `yuyv422_to_rgb`.
- **Ensures consistency** with the `save_frame()` method.
- **Corrects image data** before storing in `frame_buffer`.

# Notes

- This fix ensures real-time camera data is properly processed for accurate rendering.